### PR TITLE
보스몬스터 체력로그 수정

### DIFF
--- a/BossMonster.cpp
+++ b/BossMonster.cpp
@@ -38,9 +38,10 @@ BossMonster::BossMonster(int level)
     : Monster(level)
 {
     Name = "마왕";
-    Health = 500 + (level * 50);
-    Attack = 50 + (level * 10);
-    Defense = 40 + (level * 5);
+    Health = 500;
+    MaxHealth = Health;
+    Attack = 50;
+    Defense = 40;
     InitializeLootTable();
 }
 


### PR DESCRIPTION
이제 보스전시 보스체력이 정상적으로 표시됩니다